### PR TITLE
refactor: Rewrite Anti AFK

### DIFF
--- a/mod/build.gradle.kts
+++ b/mod/build.gradle.kts
@@ -29,7 +29,6 @@ loom {
         "client" {
             property("mixin.debug.export", "true")
             property("mixin.debug.verbose", "true")
-            property("mixin.hotSwap", "true")
             programArgs("--tweakClass", tweakerClass)
             isIdeConfigGenerated = true
         }

--- a/mod/src/main/java/net/llvg/af/AutoFish.java
+++ b/mod/src/main/java/net/llvg/af/AutoFish.java
@@ -296,7 +296,7 @@ public final class AutoFish {
         }
     }
     
-    private static synchronized void doCatch() {
+    private static void doCatch() {
         if (
           !AutoFishConfiguration.isAutoCatch() ||
           doneRightClickThisTick ||
@@ -312,7 +312,7 @@ public final class AutoFish {
         if (AutoFishConfiguration.isAntiAfk()) AutoFishAntiAfk.trigger();
     }
     
-    private static synchronized void doThrow() {
+    private static void doThrow() {
         if (
           !AutoFishConfiguration.isAutoThrow() ||
           doneRightClickThisTick ||

--- a/mod/src/main/java/net/llvg/af/AutoFishConfiguration.java
+++ b/mod/src/main/java/net/llvg/af/AutoFishConfiguration.java
@@ -17,10 +17,7 @@ import cc.polyfrost.oneconfig.config.data.Mod;
 import cc.polyfrost.oneconfig.config.data.ModType;
 import net.llvg.af.hud.HudAutoFish;
 import net.llvg.af.hud.HudFishTimer;
-import net.minecraft.client.entity.EntityPlayerSP;
 import org.jetbrains.annotations.NotNull;
-
-import static net.llvg.af.utils.Utility.*;
 
 @SuppressWarnings ({ "FieldMayBeFinal", "FieldCanBeLocal" })
 final class AutoFishConfiguration
@@ -37,6 +34,12 @@ final class AutoFishConfiguration
           true
         );
         
+        StackTraceElement trace = new Throwable().getStackTrace()[1];
+        if (
+          !AutoFishConfiguration.class.getName().equals(trace.getClassName()) ||
+          !"<clinit>".equals(trace.getMethodName())
+        ) throw new UnsupportedOperationException();
+        
         initialize();
         
         registerKeyBind(toggleKey, AutoFish::toggle);
@@ -44,12 +47,18 @@ final class AutoFishConfiguration
     }
     
     @Override
-    public void save() {
-        super.save();
-        if (!enabled) AutoFish.onConfigurationDisable();
+    public void load() {
+        super.load();
     }
     
-    static void init() { }
+    @Override
+    public void save() {
+        super.save();
+        AutoFish.logger.info("Saving configs");
+        if (!enabled) AutoFish.toggle();
+    }
+    
+    static void init() { /* For <clinit> invoke */ }
     
     @SuppressWarnings ("BooleanMethodIsAlwaysInverted")
     public static boolean isEnabled() {
@@ -336,14 +345,14 @@ final class AutoFishConfiguration
       category = CATEGORY_HUD
     )
     @SuppressWarnings ("unused")
-    private HudAutoFish hudAutoFish = HudAutoFish.instance;
+    private HudAutoFish hudAutoFish = HudAutoFish.DEFAULT;
     
     @HUD (
       name = "Fish Timer",
       category = CATEGORY_HUD
     )
     @SuppressWarnings ("unused")
-    private HudFishTimer hudFishTimer = HudFishTimer.instance;
+    private HudFishTimer hudFishTimer = HudFishTimer.DEFAULT;
     
     @Exclude
     private static final String CATEGORY_DEBUG = "Debug";
@@ -375,8 +384,7 @@ final class AutoFishConfiguration
     )
     @SuppressWarnings ("unused")
     private static void rotate() {
-        EntityPlayerSP player;
-        if ((player = mc().thePlayer) != null) AutoFishAntiAfk.trigger(player);
+        AutoFishAntiAfk.trigger();
     }
     
     @KeyBind (

--- a/mod/src/main/java/net/llvg/af/hud/HudAutoFish.java
+++ b/mod/src/main/java/net/llvg/af/hud/HudAutoFish.java
@@ -6,8 +6,10 @@ import cc.polyfrost.oneconfig.config.annotations.Text;
 import cc.polyfrost.oneconfig.hud.BasicHud;
 import cc.polyfrost.oneconfig.libs.universal.UMatrixStack;
 import net.llvg.af.AutoFish;
+import net.llvg.af.utils.AutoClosableNE;
 import org.jetbrains.annotations.Nullable;
 
+import static net.llvg.af.utils.RenderUtility.*;
 import static net.llvg.af.utils.Utility.*;
 import static org.lwjgl.opengl.GL11.*;
 
@@ -16,11 +18,9 @@ public final class HudAutoFish
   extends BasicHud
 {
     @Exclude
-    public static final HudAutoFish instance = new HudAutoFish();
+    public static final HudAutoFish DEFAULT = new HudAutoFish();
     
-    private HudAutoFish() {
-        super(false);
-    }
+    private HudAutoFish() { }
     
     @Checkbox (name = "Show When Enabled")
     private boolean showWhenEnabled = false;
@@ -45,14 +45,11 @@ public final class HudAutoFish
     private transient String _text = null;
     
     private void lookupText(boolean example) {
-        if (example) {
-            _text = "Auto Fish Text";
+        if (example) _text = "Auto Fish Text";
+        else if (AutoFish.isActive()) {
+            _text = showWhenEnabled ? textWhenEnabled : null;
         } else {
-            if (AutoFish.isActive()) {
-                _text = showWhenEnabled ? textWhenEnabled : null;
-            } else {
-                _text = showWhenDisabled ? textWhenDisabled : null;
-            }
+            _text = showWhenDisabled ? textWhenDisabled : null;
         }
     }
     
@@ -75,16 +72,16 @@ public final class HudAutoFish
     ) {
         String text;
         if ((text = _text) == null) return;
-        glPushMatrix();
-        glScalef(scale, scale, 1);
-        mc().fontRendererObj.drawString(
-          text,
-          x / scale,
-          y / scale,
-          -1,
-          drawShadow
-        );
-        glPopMatrix();
+        try (AutoClosableNE ignored = glWrapBlock()) {
+            glScalef(scale, scale, 1);
+            mc().fontRendererObj.drawString(
+              text,
+              x / scale,
+              y / scale,
+              -1,
+              drawShadow
+            );
+        }
     }
     
     @Override

--- a/mod/src/main/java/net/llvg/af/hud/HudFishTimer.java
+++ b/mod/src/main/java/net/llvg/af/hud/HudFishTimer.java
@@ -6,10 +6,12 @@ import cc.polyfrost.oneconfig.config.annotations.Number;
 import cc.polyfrost.oneconfig.hud.BasicHud;
 import cc.polyfrost.oneconfig.libs.universal.UMatrixStack;
 import net.llvg.af.AutoFish;
+import net.llvg.af.utils.AutoClosableNE;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.entity.item.EntityArmorStand;
 import org.jetbrains.annotations.Nullable;
 
+import static net.llvg.af.utils.RenderUtility.*;
 import static net.llvg.af.utils.Utility.*;
 import static org.lwjgl.opengl.GL11.*;
 
@@ -18,7 +20,7 @@ public final class HudFishTimer
   extends BasicHud
 {
     @Exclude
-    public static final HudFishTimer instance = new HudFishTimer();
+    public static final HudFishTimer DEFAULT = new HudFishTimer();
     
     private HudFishTimer() { }
     
@@ -68,11 +70,11 @@ public final class HudFishTimer
     ) {
         String text;
         if ((text = _text) == null) return;
-        glPushMatrix();
-        glScalef(scale, scale, 1);
-        FontRenderer fr = mc().fontRendererObj;
-        fr.drawString(text, x / scale + (boxWidth - fr.getStringWidth(text)) / 2, y / scale, -1, drawShadow);
-        glPopMatrix();
+        try (AutoClosableNE ignored = glWrapBlock()) {
+            glScalef(scale, scale, 1);
+            FontRenderer fr = mc().fontRendererObj;
+            fr.drawString(text, x / scale + (boxWidth - fr.getStringWidth(text)) / 2, y / scale, -1, drawShadow);
+        }
     }
     
     @Override

--- a/mod/src/main/java/net/llvg/af/mixin/MixinMinecraft.java
+++ b/mod/src/main/java/net/llvg/af/mixin/MixinMinecraft.java
@@ -64,7 +64,7 @@ public abstract class MixinMinecraft {
       at = @At (value = "HEAD")
     )
     private void rightClickMouseInject(CallbackInfo ci) {
-        AutoFish.markDoneRightClick();
+        AutoFish.onRightClick();
     }
     
     @Inject (

--- a/mod/src/main/java/net/llvg/af/utils/CullInfo.java
+++ b/mod/src/main/java/net/llvg/af/utils/CullInfo.java
@@ -24,26 +24,26 @@ public final class CullInfo {
     }
     
     public boolean getDown() {
-        return (value & 0x01) == 0;
+        return (value & 0x01) != 0;
     }
     
     public boolean getUp() {
-        return (value & 0x02) == 0;
+        return (value & 0x02) != 0;
     }
     
     public boolean getNorth() {
-        return (value & 0x04) == 0;
+        return (value & 0x04) != 0;
     }
     
     public boolean getSouth() {
-        return (value & 0x08) == 0;
+        return (value & 0x08) != 0;
     }
     
     public boolean getWest() {
-        return (value & 0x10) == 0;
+        return (value & 0x10) != 0;
     }
     
     public boolean getEast() {
-        return (value & 0x20) == 0;
+        return (value & 0x20) != 0;
     }
 }


### PR DESCRIPTION
# Buildscript Changes
- Remove client launch property `mixin.hotSwap=true` since it's not working correctly

# Backend Changes
- Store fishing hook entity and fishing timer entity as WeakReference

- Combine `waitingForHookJoin` and `waitingForHookDead` to `hookWaitingState`

- Rewrite `AutoFishAntiAfk` with `Object::wait` and `Object::notifyAll`

- Rewrite `AutoFish::onSound` with switch-case

- Using `RenderUtility::glWrapBlock` to wrap HUD rendering

- Fix some methods in `CullInfo` returns an inversed result

- Fix `AutoFishCHLavaESP` won't update when block modified in some cases