### PR TITLE
feat: Non-Async Rotation

### DIFF
--- a/mod/src/main/java/net/llvg/af/AutoFish.java
+++ b/mod/src/main/java/net/llvg/af/AutoFish.java
@@ -302,7 +302,7 @@ public final class AutoFish {
           doneRightClickThisTick ||
           !heldRod ||
           getHook() == null ||
-          hookWaitingState == null ||
+          hookWaitingState != null ||
           !catchClock.ended(AutoFishConfiguration.getAutoCatchDelay())
         ) return;
         if (AutoFishConfiguration.isVerbose()) chat("Do catch, time=", System.currentTimeMillis());
@@ -341,5 +341,9 @@ public final class AutoFish {
     
     public static void onGameStop() {
         AutoFishAntiAfk.stop();
+    }
+    
+    public static void onGameLoop() {
+        AutoFishAntiAfk.onGameLoop();
     }
 }

--- a/mod/src/main/java/net/llvg/af/AutoFishConfiguration.java
+++ b/mod/src/main/java/net/llvg/af/AutoFishConfiguration.java
@@ -131,6 +131,25 @@ final class AutoFishConfiguration
         return instance.resetFacingWhenNotFishing;
     }
     
+    @Info (
+      text = "According to Yqloss, async rotation is unsafe. So it's now disabled by default",
+      type = InfoType.WARNING,
+      subcategory = SUBCATEGORY_ANTI_AFK,
+      size = 2
+    )
+    @SuppressWarnings ("unused")
+    private Void info2 = null;
+    
+    @Checkbox (
+      name = "Use Async Rotation",
+      subcategory = SUBCATEGORY_ANTI_AFK
+    )
+    private boolean useAsyncRotation = false;
+    
+    public static boolean isUseAsyncRotation() {
+        return instance.useAsyncRotation;
+    }
+    
     @Exclude
     private static final String SUBCATEGORY_CATCH = "Catch";
     

--- a/mod/src/main/java/net/llvg/af/mixin/MixinMinecraft.java
+++ b/mod/src/main/java/net/llvg/af/mixin/MixinMinecraft.java
@@ -1,15 +1,23 @@
 package net.llvg.af.mixin;
 
 import net.llvg.af.AutoFish;
+import net.llvg.af.inject.InjectProfiler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.profiler.Profiler;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin (Minecraft.class)
 public abstract class MixinMinecraft {
+    @Shadow
+    @Final
+    public Profiler mcProfiler;
+    
     @Inject (
       method = "startGame",
       at = @At ("TAIL")
@@ -57,6 +65,18 @@ public abstract class MixinMinecraft {
     )
     private void runTickInject1(CallbackInfo ci) {
         AutoFish.onTickEnd();
+    }
+    
+    @Inject (
+      method = "runGameLoop",
+      at = @At (
+        value = "INVOKE",
+        target = "Lnet/minecraft/profiler/Profiler;startSection(Ljava/lang/String;)V",
+        shift = At.Shift.AFTER
+      )
+    )
+    private void runGameLoopInject(CallbackInfo ci) {
+        if ("tick".equals(InjectProfiler.getLastSectionName(mcProfiler))) AutoFish.onGameLoop();
     }
     
     @Inject (


### PR DESCRIPTION
# New Features

## Non-Async Rotation

> [!NOTE]
> This feature is designed for more stable rotation.
>
> According to @Yqloss, minecraft isn't designed for asynchronous operations,
> which means it's **UNSAFE** to write fields asynchronously.
>
> As a result, i've decided to create a non-asynchronous version and **make it default**.

# New Configurations

## Category `General`

### Subcategory `Anti Afk`

- New Checkbox `Use Async Rotation`
   - Default: `false`
   - Description: A toggler for asynchronous rotation

# Bug Fixes

- Fix auto catch not working due to inverted hook waiting state check